### PR TITLE
Fixed missing variable 'client_hash'

### DIFF
--- a/lib/ruby-redtail/user/contacts.rb
+++ b/lib/ruby-redtail/user/contacts.rb
@@ -62,7 +62,7 @@ module RubyRedtail
       end
 
       def build_contacts_array contact_hashes
-        if client_hashes
+        if contact_hashes
           contact_hashes.collect { |contact_hash| self.build_contact contact_hash }
         else
           raise RubyRedtail::AuthenticationError


### PR DESCRIPTION
When using user.contacts.search I was getting an undef'ed variable 'clients_hash' coming from User::Contacts#build_contacts_array
